### PR TITLE
Updated kaslr-fix.md

### DIFF
--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -74,7 +74,7 @@ Il motivo per cui abbiamo bisogno di ripristinare la mappa di memoria è che vog
   * `CSM`: per il supporto legacy, aggiunge un mucchio di spazzatura che non vogliamo. Anche questo può causare problemi in fase di avvio.
   * `Intel SGX`: Software Guard Extensions, occupa molto spazio e non ha alcuna utilità in macOS.
   * `Parallel Port`: macOS non può nemmeno sfruttare le porte parallele.
-  * `Serial Port`: Sarei curioso di sapere quanti di voi stiano debuggando il kernel...
+  * `Serial Port`: Sarei curioso di sapere quanti di voi le stiano usando per fare debug del kernel...
   * `iGPU`: Non è l'ideale, ma alcuni sistemi hanno mappe talmente grandi che l'iGPU non può adattarsi.
   * `Thunderbolt`: Molti hack non hanno il supporto Thunderbolt funzionante; le schede che non hanno dispositivi Thunderbolt ma hanno questa opzione sprecano solo più spazio.
   * `Illuminazione a LED`: Scusa amico, è ora di andare.

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -67,7 +67,7 @@ Il motivo per cui abbiamo bisogno di ripristinare la mappa di memoria è che vog
 * Aggiorna il BIOS all'ultima versione STABILE (i primi BIOS spediti sono noti per avere problemi con il memory layout, specialmente con Z390)
 * Resettare il CMOS
 * Abilitare alcune impostazioni del BIOS necessarie:
-  * `Above4GDecoding`: consente ai dispositivi PCI di utilizzare regioni di memoria superiori a 4 GB, il che significa che macOS avrà più spazio per adattarsi; può essere problematico su alcuni chipset come X99 e X299 quindi consigliamo di testare con e senza questa opzione attivata.
+  * `Above4GDecoding`: consente ai dispositivi PCI di utilizzare regioni di memoria superiori a 4 GB, il che significa che macOS avrà più spazio per adattarsi; può essere problematico su alcuni chipset come X99 e X299 quindi consigliamo di attivarla e in caso di problemi disattivarla.
     * Nota: sui BIOS del 2020 e successivi è stato introdotto il supporto al `Resizable BAR`, opzione che si sblocca con l'abilitazione di `Above4GDecoding`. Assicurarsi che il supporto al `Resizable BAR` sia disabilitato se l'opzione si presenta.
   * `Opzioni di avvio -> Modalità Windows 8.1/10`: ci assicurerà che non verranno caricate delle opzioni per dispositivi legacy. Fun fact: `Other OS` è progettato solo per l'avvio di versioni precedenti di Windows e non per altri sistemi operativi.
 * Disabilitare tutti i dispositivi non necessari nel BIOS (questo significa che ci sarà meno variazione nel memory layout ad ogni avvio, quindi meno possibilità di errori in fase di avvio). Impostazioni comuni:

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -68,7 +68,7 @@ Il motivo per cui abbiamo bisogno di ripristinare la mappa di memoria è che vog
 * Resettare il CMOS
 * Abilitare alcune impostazioni del BIOS necessarie:
   * `Above4GDecoding`: consente ai dispositivi PCI di utilizzare regioni di memoria superiori a 4 GB, il che significa che macOS avrà più spazio per adattarsi; può essere problematico su alcuni chipset come X99 e X299 quindi consigliamo di attivarla e in caso di problemi disattivarla.
-    * Nota: sui BIOS del 2020 e successivi è stato introdotto il supporto al `Resizable BAR`, opzione che si sblocca con l'abilitazione di `Above4GDecoding`. Assicurarsi che il supporto al `Resizable BAR` sia disabilitato se l'opzione si presenta.
+    * Nota: Dal 2020 nei BIOS è stato introdotto il supporto al `Resizable BAR`, opzione che si sblocca con l'abilitazione di `Above4GDecoding`. Assicurarsi che il supporto al `Resizable BAR` sia disabilitato se l'opzione si presenta.
   * `Opzioni di avvio -> Modalità Windows 8.1/10`: ci assicurerà che non verranno caricate delle opzioni per dispositivi legacy. Fun fact: `Other OS` è progettato solo per l'avvio di versioni precedenti di Windows e non per altri sistemi operativi.
 * Disabilitare tutti i dispositivi non necessari nel BIOS (questo significa che ci sarà meno variazione nel memory layout ad ogni avvio, quindi meno possibilità di errori in fase di avvio). Impostazioni comuni:
   * `CSM`: per il supporto legacy, aggiunge un mucchio di spazzatura che non vogliamo. Anche questo può causare problemi in fase di avvio.

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -62,7 +62,7 @@ E dovremo anche configurare il nostro config.plist -> Booter:
 
 ## Preparazione del BIOS
 
-Il motivo per cui abbiamo bisogno di ripristinare la mappa di memoria è che vogliamo che sia più deterministico,ossia che ci saranno meno variazioni su ogni avvio, quindi abbiamo meno casi limite (le mappe di memoria non calzano sempre a pennello). Per iniziare:
+Il motivo per cui abbiamo bisogno di ripristinare la mappa di memoria è che vogliamo che sia più stabile, che ci siano meno variazioni ad ogni avvio e di conseguenza meno casi limite (le mappe di memoria non sempre sono perfette). Per iniziare:
 
 * Aggiorna il BIOS all'ultima versione STABILE (i primi BIOS spediti sono noti per avere problemi con il memory layout, specialmente con Z390)
 * Resettare il CMOS

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -8,7 +8,7 @@ Questa sezione è per gli utenti che desiderano comprendere e correggere gli err
 
 KASLR (dall'inglese `Kernel Address Space Layout Randomization`) sta per `randomizzazione del layout dello spazio degli indirizzi del kernel` ed è un meccanismo di sicurezza per proteggere l'accesso a determinate aree di memoria relative al kernel. In particolare, per un aggressore è molto più difficile capire dove si trovano gli oggetti importanti in memoria poiché cambia ad ogni avvio del sistema operativo. [Maggiori spiegazioni riguardo al KASLR](https://lwn.net/Articles/569635/)
 
-Dove questo diventa un problema è quando si introducono dispositivi con piccole mappe di memoria o semplicemente troppi dispositivi presenti. Probabilmente c'è spazio per il funzionamento del kernel, ma c'è anche spazio libero in cui il kernel non si adatta completamente. È qui che ricorriamo a `slide = xxx`. Invece di lasciare che macOS scelga un'area casuale da utilizzare ad ogni avvio, lo costringeremo a scegliere un'area ben specifica che sappiamo funzionerà.
+KASLR diventa un problema quando si introducono dispositivi con piccole mappe di memoria o semplicemente troppi dispositivi presenti. Probabilmente c'è spazio per il funzionamento del kernel, ma c'è anche spazio libero in cui il kernel non si adatta completamente. È qui che ricorriamo a `slide = xxx`. Invece di lasciare che macOS scelga un'area casuale da utilizzare ad ogni avvio, lo costringeremo a scegliere un'area ben specifica che sappiamo funzionerà.
 
 ## E per chi sono queste informazioni?
 

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -76,7 +76,7 @@ Il motivo per cui abbiamo bisogno di ripristinare la mappa di memoria è che vog
   * `Parallel Port`: macOS non può nemmeno sfruttare le porte parallele.
   * `Serial Port`: Sarei curioso di sapere quanti di voi le stiano usando per fare debug del kernel...
   * `iGPU`: Non è l'ideale, ma alcuni sistemi hanno mappe talmente grandi che l'iGPU non può adattarsi.
-  * `Thunderbolt`: Molti hack non hanno il supporto Thunderbolt funzionante; le schede che non hanno dispositivi Thunderbolt ma hanno questa opzione sprecano solo più spazio.
+  * `Thunderbolt`: Molti hack non supportano Thunderbolt; le schede che non hanno dispositivi Thunderbolt ma che hanno questa opzione sprecano solo più spazio.
   * `Illuminazione a LED`: Scusa amico, è ora di andare.
   * `USB legacy`: più schifezze legacy.
 

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -86,7 +86,7 @@ Con le nostre impostazioni EFI, config.plist e BIOS modificate, è ora di provar
 
 ## Calcolare il valore dello slide
 
-Quello che dovrai fare è aprire una shell EFI (OpenShell, UEFIShell) nel tuo boot manager preferito ed eseguire `memmap`. L'output ti darà un elenco di tutte le pagine di memoria e delle loro relative dimensioni. È qui che inizia il divertimento.
+Quello che dovrai fare è aprire una shell EFI (OpenShell, UEFIShell) nel tuo boot manager preferito ed eseguire `memmap`. L'output ti darà un elenco di tutte le pagine di memoria e delle loro relative dimensioni. E qui inizia il divertimento:
 
 Esempio di ciò che vedrai:
 

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -155,7 +155,7 @@ Questo aggiungerà un file `memmap.txt` alla radice del tuo EFI, puoi quindi pro
 
 ## Utilizzo di DevirtualiseMmio
 
-DevirtualiseMmio è un quirk piuttosto interessante, in quanto aggira un enorme ostacolo con molte schede madri con chipset Z390 e praticamente tutte le schede madri HDET con chipset come X99 e X299. Il modo in cui lo fa è che prende le regioni MMIO e rimuove gli attributi di runtime consentendo loro di essere utilizzati comodamente come spazio per il kernel, e accoppiarlo con il quirk di `ProvideCustomSlide` significa che possiamo mantenere le funzioni di sicurezza dello slide mentre otteniamo anche una macchina avviabile.
+DevirtualiseMmio è un quirk piuttosto interessante, in quanto aggira un enorme ostacolo con molte schede madri con chipset Z390 e praticamente tutte le schede madri HDET con chipset come X99 e X299. Il modo in cui lo fa è che prende le regioni MMIO e rimuove gli attributi di runtime consentendo loro di essere utilizzati comodamente come spazio per il kernel, e accoppiarlo con il quirk `ProvideCustomSlide` significa che possiamo mantenere le funzioni di sicurezza dello slide ottenendo anche una macchina avviabile.
 
 Per sistemi estremamente problematici come i Threadripper TRX40 19h, dobbiamo trovare regioni specifiche che non sono necessarie per il corretto funzionamento. È qui che entra in gioco `MmioWhitelist`. Tieni presente che la whitelist non è richiesta per la maggior parte dei sistemi.
 

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -37,7 +37,7 @@ Fatto divertente: ci vogliono circa **31 ms** per trovare un'area in cui operare
 
 ## Allora come risolvo questo problema?
 
-La vera soluzione a questo è abbastanza semplice in realtà. Avrai bisogno di:
+La vera soluzione in realtà è abbastanza semplice. Avrai bisogno di:
 
 * **OpenCore users**:
   * [OpenRuntime](https://github.com/acidanthera/OpenCorePkg/releases)

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -6,7 +6,7 @@ Questa sezione è per gli utenti che desiderano comprendere e correggere gli err
 
 ## Dunque, cos'è questo KASLR?
 
-KASLR (dall'inglese `Kernel Address Space Layout Randomization`) che sta per `randomizzazione del layout dello spazio degli indirizzi del kernel`, è un meccanismo di sicurezza per proteggere l'accesso a determinate aree di memoria relative al kernel. In particolare, tramite questo meccanismo, è molto più difficile per un aggressore capire dove si trovano gli oggetti importanti in memoria poiché è sempre casuale tra le macchine e i vari avvii del sistema operativo. [Maggiori spiegazioni riguardo al KASLR](https://lwn.net/Articles/569635/)
+KASLR (dall'inglese `Kernel Address Space Layout Randomization`) sta per `randomizzazione del layout dello spazio degli indirizzi del kernel` ed è un meccanismo di sicurezza per proteggere l'accesso a determinate aree di memoria relative al kernel. In particolare, per un aggressore è molto più difficile capire dove si trovano gli oggetti importanti in memoria poiché cambia ad ogni avvio del sistema operativo. [Maggiori spiegazioni riguardo al KASLR](https://lwn.net/Articles/569635/)
 
 Dove questo diventa un problema è quando si introducono dispositivi con piccole mappe di memoria o semplicemente troppi dispositivi presenti. Probabilmente c'è spazio per il funzionamento del kernel, ma c'è anche spazio libero in cui il kernel non si adatta completamente. È qui che ricorriamo a `slide = xxx`. Invece di lasciare che macOS scelga un'area casuale da utilizzare ad ogni avvio, lo costringeremo a scegliere un'area ben specifica che sappiamo funzionerà.
 

--- a/extras/kaslr-fix.md
+++ b/extras/kaslr-fix.md
@@ -108,7 +108,7 @@ Esempio di ciò che vedrai:
 | BS_Data | `000000006B526000` | `000000006B625FFF` | `0000000000000100` | `000000000000000F` |
 | Available | `000000006B626000` | `000000006B634FFF` | `000000000000000F` | `000000000000000F` |
 
-Probabilmente ti starai chiedendo `come diavolo facciamo a convertirlo in un valore di Slide?`. Beh è abbastanza semplice. Quello che ci interessa è il valore più grande disponibile nella colonna `Start`. In questo esempio vediamo che `000000006B626000` è il nostro valore più grande (tieni presente che questi valori sono rappresentati in base esadecimale, quindi se ci sono più valori vicini tra loro potresti dover convertirli in base decimale). Per calcolare il valore dello slide basterà ricorrere a questa semplice formula matematica (la calcolatrice incorporata di macOS ha una funzione di programmazione premendo ⌘ + 3):
+Probabilmente ti starai chiedendo `come diavolo facciamo a convertirlo in un valore di Slide?`. Beh è abbastanza semplice. Quello che ci interessa è il valore più grande disponibile nella colonna `Start`. In questo esempio vediamo che `000000006B626000` è il nostro valore più grande (tieni presente che questi valori sono rappresentati in base esadecimale, quindi se ci sono più valori vicini tra loro potresti dover convertirli in base decimale). Per calcolare il valore dello slide basterà ricorrere a questa semplice formula matematica (la calcolatrice incorporata di macOS ha la sezione programmatore: abilitala premendo ⌘ + 3):
 
 `000000006B626000` = `0x6B626000`
 


### PR DESCRIPTION
Come on dude, you can't pretend to use Google Translate for translating a guide with complex terms like this one... There are some terms, such as `memory map, memory layout` which can't be properly translated in Italian language...
Anyways, fixed some common phrases used in the original guide, consecutio temporum and text formatting issues.
Please let me know whether you wanna get more image resources for explaining some steps
Regards
dreamwhite