### PR TITLE
Corretto un piccolo errore di traduzione

### DIFF
--- a/prerequisites.md
+++ b/prerequisites.md
@@ -26,7 +26,7 @@ Prima di iniziare seriamente a impostare un sistema basato su OpenCore, dovremmo
    * Può essere:
      * macOS (uno recente sarebbe meglio)
      * Windows (Windows 10, 1703 or più recente)
-     * Linux (Pulito e funzionante correttamente, con Python 2.7 or più recenti)
+     * Linux (Pulito e funzionante correttamente, con Python 2.7 o più recenti)
    * Per utenti Windows e Linux, **15GB** di spazio sul disco. Su Windows, il disco di sistema (C:) deve avere almeno **15GB** di spazio libero ulteriore.
    * Per utenti macOS, **30GB** di spazio sul disco di sistema.
    * La maggior parte dei tool dovranno aver [installato Python](https://www.python.org/downloads/)


### PR DESCRIPTION
Alla riga 29 c'era un errore che diceva "Python 2.7 OR più recenti" corretto con "Python 2.7 O più recenti