### PR TITLE
Update zen.md

### DIFF
--- a/config.plist/AMD/zen.md
+++ b/config.plist/AMD/zen.md
@@ -277,7 +277,6 @@ Where `<core count>` is replaced with the physical core count of your CPU in hex
 | 16 Core | `10` |
 | 24 Core | `18` |
 | 32 Core | `20` |
-| 64 Core | `40` |
 
 :::
 


### PR DESCRIPTION
Non utile in quanto OSX non supporta quel numero di cores e la CPU in questione (3990x) per funzionare necessita la disabilitazione dal Bios di HT o la forzatura a  32 cores + 32 threads
Si usa 20 come il 3970x (una volta fatte le operazioni del bios sopra citate)